### PR TITLE
(fix) Changed datatypes on two fields to string instead of date.

### DIFF
--- a/models/EKMreading.js
+++ b/models/EKMreading.js
@@ -10,8 +10,8 @@ module.exports = function( sequelize, DataTypes ) {
     Interval: DataTypes.INTEGER,
     Protocol: DataTypes.STRING,
     MAC_Addr: DataTypes.STRING,
-    Date: DataTypes.DATE,
-    Time: DataTypes.DATE,
+    Date: DataTypes.STRING,
+    Time: DataTypes.STRING,
     Time_Stamp_UTC_ms: DataTypes.DATE,
     Firmware: DataTypes.STRING,
     // had to rename Model to meterModel


### PR DESCRIPTION
Both are coming in as strings in the JSON from Push. Date was parsing correctly to PSQL, but not time. Since Tme_Stamp contains and actual UTC time string, we'll just keep that as date and save the others as strings for convenience.